### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230819.618
-jaxlib==0.4.15.dev20230819
+iree-compiler==20230820.619
+jaxlib==0.4.15.dev20230820
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,7 +7,7 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "839375f2be4375e3f71ed996d5e961e675797e2c",
+  "iree": "5bfc37a0170491929c5da8c1fd719a56078da49f",
   "xla": "51c0ad464e05c18098df7b771a7e02e1ad86dd27",
   "jax": "b4a628400f59b84a0a0bc47e828b389fc9c34bfd"
 }


### PR DESCRIPTION
* iree: 5bfc37a01 [spirv] Drop leading unit dim in f16 fused dequant matvec dispatch  (#14752) (Sat Aug 19 15:03:43 2023 +0000)
* xla: 51c0ad464 Add a transform for cross-replica-sum to all_reduce (Fri Aug 18 18:08:24 2023 -0700)
* jax: b4a628400 Update XLA dependency to use revision http://github.com/openxla/xla/commit/51c0ad464e05c18098df7b771a7e02e1ad86dd27. (Sat Aug 19 05:26:07 2023 -0700)