### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230820.619
-jaxlib==0.4.15.dev20230821
+iree-compiler==20230822.621
+jaxlib==0.4.15.dev20230822
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "5bfc37a0170491929c5da8c1fd719a56078da49f",
-  "xla": "0cd1ee17e85183b60e6680cfb8b32729dee1acc3",
-  "jax": "a14d64b160633db17048eea7732ed21380751389"
+  "iree": "2a914c1e7fbfbdecafd506c29ba30df8ea251046",
+  "xla": "1ce6e92be3d3d8fc76629c8d86913d2d13d04671",
+  "jax": "3082109a59725823672fea759c0d374f10f821ea"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 2a914c1e7 [StableHLO] Merge reshape(reshape(x)) (Tue Aug 22 05:32:08 2023 +0000)
* xla: 1ce6e92be Remove deprecated functions with no callers. (Tue Aug 22 10:53:06 2023 -0700)
* jax: 3082109a5 Add a type stub for jax.numpy. (Tue Aug 22 11:50:49 2023 -0700)