### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230903.633
-jaxlib==0.4.16.dev20230901
+iree-compiler==20230904.634
+jaxlib==0.4.16.dev20230904
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "e93cbc0817c3dcd8757a0c1f91347bed7951338d",
-  "xla": "7bd5f555f0e86efb00005dbc9e38991d5fb9765b",
-  "jax": "c527aea6a6721e3c0f89455a11d2017139dd2a16"
+  "iree": "13ef677e556d0a1d154e45b052fe016256057f65",
+  "xla": "0ec92d232eeb16f9260b57b4ae13d02e89b5de16",
+  "jax": "172ad93881c5a3a18792cf59620cdbd85a68ef01"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 13ef677e5 Add precompilation compile mode to iree-compile (#14909) (Mon Sep 4 07:01:30 2023 +0000)
* xla: 0ec92d232 Integrate LLVM at llvm/llvm-project@65b40f273f09 (Mon Sep 4 09:34:42 2023 -0700)
* jax: 172ad9388 Update XLA dependency to use revision http://github.com/openxla/xla/commit/ed8139cd8a454236028c3ab952fa5e019a537552. (Mon Sep 4 05:04:46 2023 -0700)