### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230909.640
-jaxlib==0.4.16.dev20230909
+iree-compiler==20230910.641
+jaxlib==0.4.16.dev20230910
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -8,7 +8,7 @@
 
 PINNED_VERSIONS = {
   "iree": "c3dcb9f8b73345a8fb4fe3e3d5dcef14297c0e6c",
-  "xla": "c227585959ec96a4527b1b9f9023f8d6bbe976b3",
+  "xla": "b8935098075064aba3521c200879f211d0ecc4bb",
   "jax": "292deef6fda9f639fcecd9883a1112825a1eb54f"
 }
 


### PR DESCRIPTION
* iree: c3dcb9f8b [Codegen] Only bufferize dispatches if not already bufferized (#14936) (Fri Sep 8 21:51:46 2023 +0000)
* xla: b89350980 Explicit forbid dynamic shape aliasing due to potential runtime-compiler dynamic shape size calculation mismatching (Sun Sep 10 09:57:53 2023 -0700)
* jax: 292deef6f Update XLA dependency to use revision http://github.com/openxla/xla/commit/c227585959ec96a4527b1b9f9023f8d6bbe976b3. (Sat Sep 9 04:01:14 2023 -0700)