### PR TITLE
Update nightly dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 -f https://openxla.github.io/iree/pip-release-links.html
 -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-iree-compiler==20230912.643
-jaxlib==0.4.16.dev20230912
+iree-compiler==20230913.644
+jaxlib==0.4.16.dev20230913
 -e ../jax

--- a/sync_deps.py
+++ b/sync_deps.py
@@ -7,9 +7,9 @@
 ### Update with: openxla-workspace pin
 
 PINNED_VERSIONS = {
-  "iree": "3343f24363dffa7e4602305d33627302d8c0bd6c",
-  "xla": "fe2a3c881a3b47b269b3550b33ff3e19fdd0ef67",
-  "jax": "63e51fe1e68350864b5d9b92df6055deddb8a9e5"
+  "iree": "0c3f73a4a816f54873f9550fe19c2fe5c9ba0656",
+  "xla": "7007648d74c3b848883f8d92a8358839a106b7c1",
+  "jax": "22ff7bd19a5f41941e8dea807fe37bf534487b31"
 }
 
 ORIGINS = {


### PR DESCRIPTION
* iree: 0c3f73a4a [Codegen][LLVMCPU] Use output element type to decide if reduction is over integers. (#14965) (Tue Sep 12 15:35:48 2023 -0700)
* xla: 7007648d7 Adds a new cost component for makespan. (Wed Sep 13 12:17:35 2023 -0700)
* jax: 22ff7bd19 Finish the deprecation cycle for jnp.alltrue, jnp.sometrue, jnp.product, jnp.cumproduct (Wed Sep 13 12:07:36 2023 -0700)